### PR TITLE
avoid 301 redirect adding slash at end of url

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ exports.getStories = ({
     host: 'i.instagram.com'
   }
 }) => (
-  fetch(`https://i.instagram.com/api/v1/feed/user/${id}/reel_media`, {
+  fetch(`https://i.instagram.com/api/v1/feed/user/${id}/reel_media/`, {
     headers: Object.assign(headers, {
       cookie: `sessionid=${sessionid}; ds_user_id=${userid}`
     })


### PR DESCRIPTION
It doing a request to `https://i.instagram.com/api/v1/feed/user/11111111/reel_media` gets a response with a status code 301 (redirect) pointing to same url with a slash at end but Fetch can not to handler redirections.